### PR TITLE
Fix mobile home navigation layout

### DIFF
--- a/public/css/home.css
+++ b/public/css/home.css
@@ -39,20 +39,46 @@ body {
     background-repeat: no-repeat;
     min-height: 100vh;
   }
-  #navbarResponsive { width: 100vw; }
+  /* Stack logo above menu button */
+  .navbar .container {
+    flex-direction: column;
+    align-items: center;
+  }
+  .navbar-toggler {
+    margin-left: 0;
+    margin-top: 0.5rem;
+    z-index: 1100;
+  }
+  #navbarResponsive {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0, 0, 0, 0.9);
+    display: none;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+  }
+  #navbarResponsive.show {
+    display: flex;
+  }
   #navbarResponsive .navbar-nav {
     width: 100%;
     text-align: center;
   }
   #navbarResponsive .navbar-nav .nav-item {
     width: 100%;
-    padding: 1rem 0;
-    border-bottom: 1px solid rgba(255,255,255,0.1);
+    margin: 1rem 0;
+    border: none;
   }
   #navbarResponsive .navbar-nav .nav-link {
     display: block;
     width: 100%;
-    font-size: 1.2rem;
+    font-size: 1.5rem;
+    color: #fff;
   }
 }
 

--- a/routes/home.html
+++ b/routes/home.html
@@ -56,30 +56,32 @@
             float: none !important;
             text-align: center;
         }
-        /* Adjust container for full width and center content */
-        .navbar .container {
-            display: flex;
-            flex-direction: row;
-            justify-content: center;
-            align-items: center;
-            position: relative;
-        }
-        /* Position toggler on the right */
-        .navbar-toggler {
-            margin-left: auto;
-            cursor: pointer;
-            font-size: 1.5rem;
-            padding: 0.75rem 1.2rem;
-        }
+        /* Mobile layout: stack logo and menu button, full screen menu */
         @media (max-width: 768px) {
-            /* Center the logo on mobile and make menu full width */
-            .navbar .navbar-brand {
-                position: absolute;
-                left: 50%;
-                transform: translateX(-50%);
+            .navbar .container {
+                flex-direction: column;
+                align-items: center;
+            }
+            .navbar-toggler {
+                margin-left: 0;
+                margin-top: 0.5rem;
+                z-index: 1100;
             }
             #navbarResponsive {
+                position: fixed;
+                top: 0;
+                left: 0;
                 width: 100vw;
+                height: 100vh;
+                background: rgba(0,0,0,0.9);
+                display: none;
+                flex-direction: column;
+                justify-content: center;
+                align-items: center;
+                z-index: 1000;
+            }
+            #navbarResponsive.show {
+                display: flex;
             }
             #navbarResponsive .navbar-nav {
                 width: 100%;
@@ -87,13 +89,14 @@
             }
             #navbarResponsive .navbar-nav .nav-item {
                 width: 100%;
-                padding: 1rem 0;
-                border-bottom: 1px solid rgba(255,255,255,0.1);
+                margin: 1rem 0;
+                border: none;
             }
             #navbarResponsive .navbar-nav .nav-link {
                 display: block;
                 width: 100%;
-                font-size: 1.2rem;
+                font-size: 1.5rem;
+                color: #fff;
             }
         }
         /* Raise the navbar above overlays */
@@ -111,7 +114,7 @@
             <a class="navbar-brand js-scroll-trigger" id="logoMenu" href="#">
                 <img id="l1" src="/images/t1.png" alt="Autorizz">
             </a>
-            <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
+            <button class="navbar-toggler" type="button" data-toggle="collapse"
                     data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false"
                     aria-label="Toggle navigation">
                 Menu <i class="fas fa-bars"></i>
@@ -198,23 +201,15 @@ Our site is designed to make the car‑shopping journey simple and engaging. Bro
 
     <footer class="copyright-footer">© Offroad Studios</footer>
 
-    <!-- Only load ONE jQuery, then Bootstrap bundle -->
+    <!-- Scripts -->
     <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.bundle.min.js"></script>
-    <!-- Smart workaround: logo toggles menu on mobile -->
     <script>
-    document.addEventListener('DOMContentLoaded', function () {
-      var logo = document.getElementById('logoMenu');
-      var navbarCollapse = document.getElementById('navbarResponsive');
-      if (logo && navbarCollapse) {
-        logo.addEventListener('click', function (e) {
-          if (window.innerWidth <= 768) { // Only on mobile
-            e.preventDefault();
-            navbarCollapse.classList.toggle('show'); // Bootstrap toggles menu with .show
-          }
+      $(function () {
+        $('#navbarResponsive .nav-link').on('click', function () {
+          $('#navbarResponsive').collapse('hide');
         });
-      }
-    });
+      });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Center home logo and position menu button below it on small screens
- Add full-screen overlay menu with large touch-friendly links on mobile
- Collapse the overlay when a navigation link is selected

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6890ee5e358c8329b552dcbff807fd10