### PR TITLE
feat: add admin navigation

### DIFF
--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -24,6 +24,30 @@ img {
 }
 
 .record_list {
-    width: 240%;
-    margin: 2rem 1rem;
+    max-width: 800px;
+    margin: 2rem auto;
+}
+
+.navbar .btn {
+    margin-left: 0.5rem;
+}
+
+/* WhatsApp floating button */
+.whatsapp-float {
+    position: fixed;
+    width: 60px;
+    height: 60px;
+    bottom: 40px;
+    right: 40px;
+    background-color: #25d366;
+    color: #FFF;
+    border-radius: 50px;
+    text-align: center;
+    font-size: 30px;
+    box-shadow: 2px 2px 3px #999;
+    z-index: 100;
+}
+
+.whatsapp-icon {
+    margin-top: 16px;
 }

--- a/public/css/home.css
+++ b/public/css/home.css
@@ -173,3 +173,22 @@ img::-moz-selection, img::selection { background: 0 0; }
     border-radius: 0.4rem;
   }
 }
+/* WhatsApp floating button */
+.whatsapp-float {
+    position: fixed;
+    width: 60px;
+    height: 60px;
+    bottom: 40px;
+    right: 40px;
+    background-color: #25d366;
+    color: #FFF;
+    border-radius: 50px;
+    text-align: center;
+    font-size: 30px;
+    box-shadow: 2px 2px 3px #999;
+    z-index: 100;
+}
+
+.whatsapp-icon {
+    margin-top: 16px;
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -253,7 +253,7 @@ p{
     border-radius: 25px;
     border-width: 2.5px;
 }
-  
+
 #b1:hover {
     height: 40px;
     width: 130px;
@@ -262,5 +262,25 @@ p{
     color: white;
     border-radius: 25px;
     border-width: 2.5px;
+}
+
+/* WhatsApp floating button */
+.whatsapp-float {
+    position: fixed;
+    width: 60px;
+    height: 60px;
+    bottom: 40px;
+    right: 40px;
+    background-color: #25d366;
+    color: #FFF;
+    border-radius: 50px;
+    text-align: center;
+    font-size: 30px;
+    box-shadow: 2px 2px 3px #999;
+    z-index: 100;
+}
+
+.whatsapp-icon {
+    margin-top: 16px;
 }
 

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -42,7 +42,7 @@ router.post("/login", async function (req, res) {
         console.log(user);
         if (user && pass === user.password) {
             console.log("Login Success");
-            res.redirect("/admin/admin_index");
+            res.redirect("/admin/hatchback");
         } else {
             res.redirect("login_error");
         }
@@ -55,6 +55,11 @@ router.post("/login", async function (req, res) {
 // GET - Home Page
 router.get('/home', function (req, res) {
     res.sendFile(__dirname + "/admin_home.html");
+});
+
+// GET Admin logout
+router.get('/logout', function (req, res) {
+    res.redirect('/admin');
 });
 
 // GET Service Page

--- a/routes/home.html
+++ b/routes/home.html
@@ -199,6 +199,10 @@ Our site is designed to make the car‑shopping journey simple and engaging. Bro
         </div>
     </div>
 
+    <a href="https://wa.me/923166666602" class="whatsapp-float" target="_blank" aria-label="WhatsApp">
+        <i class="fab fa-whatsapp whatsapp-icon"></i>
+    </a>
+
     <footer class="copyright-footer">© Offroad Studios</footer>
 
     <!-- Scripts -->

--- a/views/admin/hatchback_list.hbs
+++ b/views/admin/hatchback_list.hbs
@@ -1,10 +1,9 @@
-<h2>All Hatchback Cars</h2>
-<a href="/admin/addhatchback">Add New Hatchback</a>
-<ul>
+<h2 class="mb-3">All Hatchback Cars</h2>
+<ul class="list-group">
 {{#each list}}
-    <li>
-        <strong>{{title}}</strong> - {{brand}} ({{year}}) - ${{price}}
-        <a href="/admin/deletehatchback/{{_id}}">Delete</a>
+    <li class="list-group-item d-flex justify-content-between align-items-center">
+        <span><strong>{{title}}</strong> - {{brand}} ({{year}}) - ${{price}}</span>
+        <a class="btn btn-sm btn-danger" href="/admin/deletehatchback/{{_id}}">Delete</a>
     </li>
 {{/each}}
 </ul>

--- a/views/admin/saloon_list.hbs
+++ b/views/admin/saloon_list.hbs
@@ -1,10 +1,9 @@
-<h2>All Saloon Cars</h2>
-<a href="/admin/addsaloon">Add New Saloon</a>
-<ul>
+<h2 class="mb-3">All Saloon Cars</h2>
+<ul class="list-group">
 {{#each list}}
-    <li>
-        <strong>{{title}}</strong> - {{brand}} ({{year}}) - ${{price}}
-        <a href="/admin/deletesaloon/{{_id}}">Delete</a>
+    <li class="list-group-item d-flex justify-content-between align-items-center">
+        <span><strong>{{title}}</strong> - {{brand}} ({{year}}) - ${{price}}</span>
+        <a class="btn btn-sm btn-danger" href="/admin/deletesaloon/{{_id}}">Delete</a>
     </li>
 {{/each}}
 </ul>

--- a/views/admin/suv_list.hbs
+++ b/views/admin/suv_list.hbs
@@ -1,10 +1,9 @@
-<h2>All SUV Cars</h2>
-<a href="/admin/addsuv">Add New SUV</a>
-<ul>
+<h2 class="mb-3">All SUV Cars</h2>
+<ul class="list-group">
 {{#each list}}
-    <li>
-        <strong>{{title}}</strong> - {{brand}} ({{year}}) - ${{price}}
-        <a href="/admin/deletesuv/{{_id}}">Delete</a>
+    <li class="list-group-item d-flex justify-content-between align-items-center">
+        <span><strong>{{title}}</strong> - {{brand}} ({{year}}) - ${{price}}</span>
+        <a class="btn btn-sm btn-danger" href="/admin/deletesuv/{{_id}}">Delete</a>
     </li>
 {{/each}}
 </ul>

--- a/views/hatchback_index.hbs
+++ b/views/hatchback_index.hbs
@@ -242,9 +242,8 @@
                             <h4>${{this.priceStr}}</h4>
                         </div>
                         <div class="col-sm text-center buybutton">
-                            <a style="color: white;" href="booknow/{{this._id}}">
-                                <button id="b1" type="button" class="btn btn-outline-light"> Book Now
-                                </button>
+                            <a class="btn btn-success" href="https://wa.me/923166666602" target="_blank" aria-label="WhatsApp">
+                                <i class="fab fa-whatsapp"></i>
                             </a>
                         </div>
                     </div>

--- a/views/layouts/layout.hbs
+++ b/views/layouts/layout.hbs
@@ -76,6 +76,9 @@
 
 
     {{{body}}}
+    <a href="https://wa.me/923166666602" class="whatsapp-float" target="_blank" aria-label="WhatsApp">
+        <i class="fab fa-whatsapp whatsapp-icon"></i>
+    </a>
 
 <footer class="copyright-footer">© Offroad Studios</footer>
 

--- a/views/layouts/layout_list.hbs
+++ b/views/layouts/layout_list.hbs
@@ -20,14 +20,23 @@
 </head>
 
 <body>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+        <a class="navbar-brand" href="/">Home</a>
+        <div class="ml-auto">
+            <a class="btn btn-outline-primary mr-2" href="/admin/addhatchback">Add Hatchback</a>
+            <a class="btn btn-outline-primary mr-2" href="/admin/addsuv">Add SUV</a>
+            <a class="btn btn-outline-primary mr-2" href="/admin/addsaloon">Add Saloon</a>
+            <a class="btn btn-danger" href="/admin/logout">Logout</a>
+        </div>
+    </nav>
 
-    <div class="record_list">
-
+    <div class="record_list container mt-4">
         {{{body}}}
-
     </div>
 
-
+    <a href="https://wa.me/923166666602" class="whatsapp-float" target="_blank" aria-label="WhatsApp">
+        <i class="fab fa-whatsapp whatsapp-icon"></i>
+    </a>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
     {{!--
@@ -40,8 +49,6 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
         crossorigin="anonymous"></script>
-
-
 </body>
 
 </html>

--- a/views/saloon_index.hbs
+++ b/views/saloon_index.hbs
@@ -338,9 +338,8 @@
                             <h4>${{this.priceStr}}</h4>
                         </div>
                         <div class="col-sm text-center buybutton">
-                            <a style="color: white;" href="booknow/{{this._id}}">
-                                <button id="b1" type="button" class="btn btn-outline-light"> Book Now
-                                </button>
+                            <a class="btn btn-success" href="https://wa.me/923166666602" target="_blank" aria-label="WhatsApp">
+                                <i class="fab fa-whatsapp"></i>
                             </a>
                         </div>
                     </div>

--- a/views/suv_index.hbs
+++ b/views/suv_index.hbs
@@ -338,9 +338,8 @@
                             <h4>${{this.priceStr}}</h4>
                         </div>
                         <div class="col-sm text-center buybutton">
-                            <a style="color: white;" href="booknow/{{this._id}}">
-                                <button id="b1" type="button" class="btn btn-outline-light"> Book Now
-                                </button>
+                            <a class="btn btn-success" href="https://wa.me/923166666602" target="_blank" aria-label="WhatsApp">
+                                <i class="fab fa-whatsapp"></i>
                             </a>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Redirect admins to hatchback manager after login and provide navigation to other car forms
- Style hatchback, SUV, and saloon lists with Bootstrap and center layout
- Add logout route for returning to login
- Add persistent WhatsApp contact link and replace "Book Now" buttons with WhatsApp icons
- Display WhatsApp contact icon on the home page

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68928ce1dd58832985599c760d9c36f0