### PR TITLE
Add edit functionality for car listings

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -133,6 +133,39 @@ router.post('/addhatchback', upload, async function (req, res) {
     }
 });
 
+// Edit Hatchback Car Form
+router.get('/edithatchback/:id', async function (req, res) {
+    try {
+        let hatchback = await HatchbackModel.findById(req.params.id);
+        res.render("admin/hatchback_edit", { car: hatchback, layout: false });
+    } catch (err) {
+        console.error('Error loading hatchback:', err);
+        res.status(500).send('Failed to load hatchback.');
+    }
+});
+
+// Update Hatchback Car
+router.post('/edithatchback/:id', upload, async function (req, res) {
+    try {
+        let updateData = {
+            title: req.body.title,
+            brand: req.body.brand,
+            year: req.body.year,
+            price: req.body.price,
+            fuelType: req.body.fuelType,
+            description: req.body.description
+        };
+        if (req.file) {
+            updateData.imagePath = 'images/' + req.file.originalname;
+        }
+        await HatchbackModel.findByIdAndUpdate(req.params.id, updateData);
+        res.redirect('/admin/hatchback');
+    } catch (err) {
+        console.error('Error updating hatchback:', err);
+        res.status(500).send('Failed to update hatchback.');
+    }
+});
+
 // Delete Hatchback
 router.get('/deletehatchback/:id', async function (req, res) {
     try {
@@ -179,6 +212,39 @@ router.post('/addsuv', upload, async function (req, res) {
     }
 });
 
+// Edit SUV Car Form
+router.get('/editsuv/:id', async function (req, res) {
+    try {
+        let suv = await SUVModel.findById(req.params.id);
+        res.render("admin/suv_edit", { car: suv, layout: false });
+    } catch (err) {
+        console.error('Error loading SUV:', err);
+        res.status(500).send('Failed to load SUV.');
+    }
+});
+
+// Update SUV Car
+router.post('/editsuv/:id', upload, async function (req, res) {
+    try {
+        let updateData = {
+            title: req.body.title,
+            brand: req.body.brand,
+            year: req.body.year,
+            price: req.body.price,
+            fuelType: req.body.fuelType,
+            description: req.body.description
+        };
+        if (req.file) {
+            updateData.imagePath = 'images/' + req.file.originalname;
+        }
+        await SUVModel.findByIdAndUpdate(req.params.id, updateData);
+        res.redirect('/admin/suv');
+    } catch (err) {
+        console.error('Error updating SUV:', err);
+        res.status(500).send('Failed to update SUV.');
+    }
+});
+
 // Delete SUV
 router.get('/deletesuv/:id', async function (req, res) {
     try {
@@ -222,6 +288,39 @@ router.post('/addsaloon', upload, async function (req, res) {
     } catch (err) {
         console.error('Error adding saloon:', err);
         res.status(500).send('Failed to add saloon.');
+    }
+});
+
+// Edit Saloon Car Form
+router.get('/editsaloon/:id', async function (req, res) {
+    try {
+        let saloon = await SaloonModel.findById(req.params.id);
+        res.render("admin/saloon_edit", { car: saloon, layout: false });
+    } catch (err) {
+        console.error('Error loading saloon:', err);
+        res.status(500).send('Failed to load saloon.');
+    }
+});
+
+// Update Saloon Car
+router.post('/editsaloon/:id', upload, async function (req, res) {
+    try {
+        let updateData = {
+            title: req.body.title,
+            brand: req.body.brand,
+            year: req.body.year,
+            price: req.body.price,
+            fuelType: req.body.fuelType,
+            description: req.body.description
+        };
+        if (req.file) {
+            updateData.imagePath = 'images/' + req.file.originalname;
+        }
+        await SaloonModel.findByIdAndUpdate(req.params.id, updateData);
+        res.redirect('/admin/saloon');
+    } catch (err) {
+        console.error('Error updating saloon:', err);
+        res.status(500).send('Failed to update saloon.');
     }
 });
 

--- a/views/admin/hatchback_edit.hbs
+++ b/views/admin/hatchback_edit.hbs
@@ -1,0 +1,13 @@
+<h2>Edit Hatchback Car</h2>
+<form action="/admin/edithatchback/{{car._id}}" method="POST" enctype="multipart/form-data">
+    <input name="title" placeholder="Title" value="{{car.title}}" required>
+    <input name="brand" placeholder="Brand" value="{{car.brand}}" required>
+    <input name="year" placeholder="Year" value="{{car.year}}" required>
+    <input name="price" placeholder="Price" type="number" value="{{car.price}}" required>
+    <input name="fuelType" placeholder="Fuel Type" value="{{car.fuelType}}">
+    <input type="file" name="imageupld" accept="image/*">
+    <textarea name="description" placeholder="Description">{{car.description}}</textarea>
+    <button type="submit">Update Hatchback</button>
+</form>
+<a href="/admin/hatchback">Back to Hatchback List</a>
+

--- a/views/admin/hatchback_list.hbs
+++ b/views/admin/hatchback_list.hbs
@@ -3,7 +3,10 @@
 {{#each list}}
     <li class="list-group-item d-flex justify-content-between align-items-center">
         <span><strong>{{title}}</strong> - {{brand}} ({{year}}) - ${{price}}</span>
-        <a class="btn btn-sm btn-danger" href="/admin/deletehatchback/{{_id}}">Delete</a>
+        <span>
+            <a class="btn btn-sm btn-secondary mr-2" href="/admin/edithatchback/{{_id}}">Edit</a>
+            <a class="btn btn-sm btn-danger" href="/admin/deletehatchback/{{_id}}">Delete</a>
+        </span>
     </li>
 {{/each}}
 </ul>

--- a/views/admin/saloon_edit.hbs
+++ b/views/admin/saloon_edit.hbs
@@ -1,0 +1,13 @@
+<h2>Edit Saloon Car</h2>
+<form action="/admin/editsaloon/{{car._id}}" method="POST" enctype="multipart/form-data">
+    <input name="title" placeholder="Title" value="{{car.title}}" required>
+    <input name="brand" placeholder="Brand" value="{{car.brand}}" required>
+    <input name="year" placeholder="Year" value="{{car.year}}" required>
+    <input name="price" placeholder="Price" type="number" value="{{car.price}}" required>
+    <input name="fuelType" placeholder="Fuel Type" value="{{car.fuelType}}">
+    <input type="file" name="imageupld" accept="image/*">
+    <textarea name="description" placeholder="Description">{{car.description}}</textarea>
+    <button type="submit">Update Saloon</button>
+</form>
+<a href="/admin/saloon">Back to Saloon List</a>
+

--- a/views/admin/saloon_list.hbs
+++ b/views/admin/saloon_list.hbs
@@ -3,7 +3,10 @@
 {{#each list}}
     <li class="list-group-item d-flex justify-content-between align-items-center">
         <span><strong>{{title}}</strong> - {{brand}} ({{year}}) - ${{price}}</span>
-        <a class="btn btn-sm btn-danger" href="/admin/deletesaloon/{{_id}}">Delete</a>
+        <span>
+            <a class="btn btn-sm btn-secondary mr-2" href="/admin/editsaloon/{{_id}}">Edit</a>
+            <a class="btn btn-sm btn-danger" href="/admin/deletesaloon/{{_id}}">Delete</a>
+        </span>
     </li>
 {{/each}}
 </ul>

--- a/views/admin/suv_edit.hbs
+++ b/views/admin/suv_edit.hbs
@@ -1,0 +1,13 @@
+<h2>Edit SUV Car</h2>
+<form action="/admin/editsuv/{{car._id}}" method="POST" enctype="multipart/form-data">
+    <input name="title" placeholder="Title" value="{{car.title}}" required>
+    <input name="brand" placeholder="Brand" value="{{car.brand}}" required>
+    <input name="year" placeholder="Year" value="{{car.year}}" required>
+    <input name="price" placeholder="Price" type="number" value="{{car.price}}" required>
+    <input name="fuelType" placeholder="Fuel Type" value="{{car.fuelType}}">
+    <input type="file" name="imageupld" accept="image/*">
+    <textarea name="description" placeholder="Description">{{car.description}}</textarea>
+    <button type="submit">Update SUV</button>
+</form>
+<a href="/admin/suv">Back to SUV List</a>
+

--- a/views/admin/suv_list.hbs
+++ b/views/admin/suv_list.hbs
@@ -3,7 +3,10 @@
 {{#each list}}
     <li class="list-group-item d-flex justify-content-between align-items-center">
         <span><strong>{{title}}</strong> - {{brand}} ({{year}}) - ${{price}}</span>
-        <a class="btn btn-sm btn-danger" href="/admin/deletesuv/{{_id}}">Delete</a>
+        <span>
+            <a class="btn btn-sm btn-secondary mr-2" href="/admin/editsuv/{{_id}}">Edit</a>
+            <a class="btn btn-sm btn-danger" href="/admin/deletesuv/{{_id}}">Delete</a>
+        </span>
     </li>
 {{/each}}
 </ul>


### PR DESCRIPTION
## Summary
- Allow admin to edit existing hatchback, SUV, and saloon entries.
- Provide edit forms and add Edit links in car lists.

## Testing
- `node --check routes/admin.js`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f93e783f8832989321d036069ddf4